### PR TITLE
Sd radiozerocheck

### DIFF
--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -4,7 +4,11 @@ import { getFacilities, getFacilityMinerals, getMinerals, getTransientState, set
 export const FacilitiesSelect = () => {
     const transientstate = getTransientState()
     const facilities = getFacilities()
-    let html = `<select id="facility"> <option value="0">---Select a facility---</option>`//intiates select field and adds default option
+    let html = `<select id="facility"`
+    if (transientstate.selectedGovernor === undefined) { //if no governor selected, disables the facility dropdown
+        html +=" disabled"
+    }
+    html += `> <option value="0">---Select a facility---</option>`//intiates select field and adds default option
     facilities.map( //loops through facilities and adds each option to the html
         (facility) => {
             html += `<option value="${facility.id}"`


### PR DESCRIPTION
# Description

Added both a zero-check for quantity of minerals before displaying its associated radio button, as well as a governor-selected check for the facility select. if a governor is not selected, the facility dropdown will be disabled

Fixes #2 theoretical final

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] serve to chrome. facility select should be disabled. after selecting a governor should be enabled
- [x] select a facility and verify its minerals. find the associated entry for one of the minerals in facilityminerals in database module, set mineralquantity to 0. reload page, select same facility, verify that mineral's radio button no longer shows

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
