### PR TITLE
fixed bug where cart item retained mineral when selecting a different…

### DIFF
--- a/scripts/Facilities/FacilityMinerals.js
+++ b/scripts/Facilities/FacilityMinerals.js
@@ -19,12 +19,12 @@ export const FacilityMinerals = () => {
               if (transientstate.selectedMineral === facMineral.mineralId ) {
               
                 html += `<li> 
-                <input type="radio" name="mineral_${displayedFacility.id}" value="${facMineral.mineralId}" checked="checked" /> ${facMineral.mineralQuanitity} tons of ${minName.mineralName}
+                <input type="radio" name="mineralFacility_${displayedFacility.id}" value="${facMineral.mineralId}" checked="checked" /> ${facMineral.mineralQuanitity} tons of ${minName.mineralName}
                 </li>`
 
               } else {
               html += `<li> 
-                <input type="radio" name="mineral_${displayedFacility.id}" value="${facMineral.mineralId}" /> ${facMineral.mineralQuanitity} tons of ${minName.mineralName}
+                <input type="radio" name="mineralFacility_${displayedFacility.id}" value="${facMineral.mineralId}" /> ${facMineral.mineralQuanitity} tons of ${minName.mineralName}
                 </li>` //construct an html line-item. current setup limits minerals to 1 of each type per purchase. can remove "name" field to enable multi-purchase. event listen would target "type" in that case, since we only have one set of radio buttons
                }
             }

--- a/scripts/Facilities/FacilitySelect.js
+++ b/scripts/Facilities/FacilitySelect.js
@@ -1,4 +1,4 @@
-import { getFacilities, getTransientState, setFacility } from "../database.js"
+import { getFacilities, getTransientState, resetSelectedMineral, setFacility } from "../database.js"
 
 
 
@@ -23,8 +23,8 @@ export const FacilitiesSelect = () => {
 
 document.addEventListener("change", (event) => {
     if (event.target.id === "facility") {
+        resetSelectedMineral()
         setFacility(parseInt(event.target.value)) //references a pre-established setter to set a transient state property.
-        
     }
 })
 

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -207,3 +207,11 @@ const addToColony = () => {
     }
 
 }
+
+export const resetSelectedMineral = () => {
+    if (database.transientState.selectedMineral) {
+        database.transientState.selectedMineral = null
+    }
+    // document.dispatchEvent(new CustomEvent("stateChanged"))
+
+}


### PR DESCRIPTION
… facility - selectedMineral state is now cleared every time a new facility is selected from dropdown

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Created a new "resetSelectedMineral" function in database that is then invoked during the facilityName event listener.


Fixes #81

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] serve to browser. Select a governor, then facility, then select a mineral. Before purchasing, select a different facility from the dropdown list. The selectedMineral state should change and the cart item description should disappear.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
